### PR TITLE
Correção de de diretórios 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,4 +127,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-/data/image_and_masks/train_imgs/train
+#/data/image_and_masks/train_imgs/train


### PR DESCRIPTION
Aparentemente o github desconsidera pastas vazias, com isso criei um .txt no último diretório que vai armazenar as imagens para que ele não suma.